### PR TITLE
Fixed typo in RHESSI_Solar_Flare_Prediction.ipynb

### DIFF
--- a/RHESSI_Solar_Flare_Prediction.ipynb
+++ b/RHESSI_Solar_Flare_Prediction.ipynb
@@ -62,7 +62,7 @@
     "Dur[s] - Numeric - Duration of flare in seconds\n",
     "Peak[c/s] - Numeric - Peak count rate in corrected counts, peak counts/second\n",
     "Total Counts - Numeric -  Total of counts in corrected counts, counts in energy range\n",
-    "Energy [keV] - String - No DescriptionThe highest energy band in which the flare was observed.\n",
+    "Energy [keV] - String - The highest energy band in which the flare was observed.\n",
     "X pos [asec] -  Numeric -  Flare position in arcsec from sun center\n",
     "Y pos [asec] - Numeric -  Flare position in arcsec from sun center\n",
     "Radial [asec] - Radial distance in arcsec from sun center\n",


### PR DESCRIPTION
Removed 'No Description' from Energy as it has some description